### PR TITLE
Update Data.ISeq

### DIFF
--- a/src/Data/ISeq.hs
+++ b/src/Data/ISeq.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Data.ISeq where
 
 import Prelude hiding ( seq )
@@ -12,44 +13,38 @@ iNewline :: ISeq
 iIndent :: ISeq -> ISeq
 iDisplay :: ISeq -> String
 
--- |
--- Following 'iConcat' and 'iInterleave' implementations are exercise 1.2
+#if __CLH_EXERCISE_1__ >= 2
 iConcat :: [ISeq] -> ISeq
 iConcat = foldl iAppend iNil
 
 iInterleave :: ISeq -> [ISeq] -> ISeq
 iInterleave _ [] = iNil
-iInterleave sep (seq : seqs) = foldl (\acc s -> acc `iAppend` sep `iAppend` s) seq seqs
+iInterleave sep (seq : seqs) = foldl (\s acc -> s `iAppend` sep `iAppend` acc) seq seqs
 
--- |
--- Following definitions do not support indenting.
-{-
+#if __CLH_EXERCISE_1__ < 6
 data ISeq
   = INil
   | IStr String
   | IAppend ISeq ISeq
--}
+#endif
 
 iNil = INil
--- |
--- Before exercise 1.7
-{-
+
+#if __CLH_EXERCISE_1__ < 7
 iStr = IStr
--}
--- |
--- Before exercise 1.5
-{-
+#endif
+
+#if __CLH_EXERCISE_1__ < 5
 iAppend = IAppend
--}
--- |
--- Following implementation of 'iAppend' is exercise 1.5
+#endif
+
+#if __CLH_EXERCISE_1__ >= 5
 iAppend INil INil = INil
 iAppend INil seq2 = seq2
 iAppend seq1 INil = seq1
 iAppend seq1 seq2 = IAppend seq1 seq2
--- |
--- Following definitions do not support indenting.
-{-
+
+#if __CLH_EXERCISE_1__ < 6
 iIndent seq = seq
 iNewline = IStr "\n"
 
@@ -61,8 +56,9 @@ flatten [] = ""
 flatten (INil : seqs) = flatten seqs
 flatten (IStr s : seqs) = s ++ flatten seqs
 flatten (IAppend seq1 seq2 : seqs) = flatten (seq1 : seq2 : seqs)
--}
+#endif
 
+#if __CLH_EXERCISE_1__ >= 6
 data ISeq
   = INil
   | IStr String
@@ -71,6 +67,7 @@ data ISeq
   | INewline
 
 iIndent = IIndent
+
 iNewline = INewline
 
 flatten :: Int -> [(ISeq, Int)] -> String
@@ -81,20 +78,17 @@ flatten _ ((INewline, indent) : seqs)
   = '\n' : space indent ++ flatten indent seqs
 flatten col ((IIndent seq, _) : seqs)
   = flatten col ((seq, col) : seqs)
--- |
--- Following patterns for 'flatten' are parts of exercise 1.6
 flatten col ((IAppend seq1 seq2, indent) : seqs)
   = flatten col ((seq1, indent) : (seq2, indent) : seqs)
 flatten col ((IStr s, _) : seqs) = s ++ flatten (col + length s) seqs
 flatten col ((INil, _) : seqs) = flatten col seqs
 flatten _ [] = ""
 
--- |
--- Following implementation of 'iStr' is exercise 1.7
+#if __CLH_EXERCISE_1__ >= 7
 iStr = iConcat . intersperse INewline . map IStr . lines
+#endif
 
--- |
--- Following 'iPrecParen' implementation is a part of exercise 1.8
+#if __CLH_EXERCISE_1__ >= 8
 iPrecParen :: Int -> Int -> ISeq -> ISeq
 iPrecParen contextPrec currentPrec seq
   | contextPrec > currentPrec = iConcat [ iStr "(", seq, iStr ")" ]
@@ -117,3 +111,7 @@ iLayn seqs
   where
     layItem n seq
       = iConcat [ iFWNum 4 n, iStr ") ", iIndent seq, iNewline ]
+#endif
+#endif
+#endif
+#endif

--- a/src/Data/ISeq.hs
+++ b/src/Data/ISeq.hs
@@ -15,11 +15,10 @@ iDisplay :: ISeq -> String
 
 #if __CLH_EXERCISE_1__ >= 2
 iConcat :: [ISeq] -> ISeq
-iConcat = foldl iAppend iNil
+iConcat = foldr iAppend iNil
 
 iInterleave :: ISeq -> [ISeq] -> ISeq
-iInterleave _ [] = iNil
-iInterleave sep (seq : seqs) = foldl (\s acc -> s `iAppend` sep `iAppend` acc) seq seqs
+iInterleave sep seqs = foldr iAppend iNil (intersperse sep seqs)
 
 #if __CLH_EXERCISE_1__ < 6
 data ISeq
@@ -34,15 +33,15 @@ iNil = INil
 iStr = IStr
 #endif
 
-#if __CLH_EXERCISE_1__ < 5
+#if __CLH_EXERCISE_1__ != 5
 iAppend = IAppend
 #endif
 
-#if __CLH_EXERCISE_1__ >= 5
-iAppend INil INil = INil
+#if __CLH_EXERCISE_1__ == 5
 iAppend INil seq2 = seq2
 iAppend seq1 INil = seq1
 iAppend seq1 seq2 = IAppend seq1 seq2
+#endif
 
 #if __CLH_EXERCISE_1__ < 6
 iIndent seq = seq
@@ -111,7 +110,6 @@ iLayn seqs
   where
     layItem n seq
       = iConcat [ iFWNum 4 n, iStr ") ", iIndent seq, iNewline ]
-#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
Current `ISeq` is quite strict, or in other words, its part cannot be displayed independently.
With this situation, one cannot solve the exercise 4.26, since it requires non-strictness of `ISeq`.

This PR resolves this issue by making `ISeq` interfaces less strict.